### PR TITLE
translate snippets for titles

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -27,7 +27,8 @@ foreach (WP_API_YOAST_POST_TYPES as $type) {
         'primary_category'      => get_post_meta($post['id'], '_yoast_wpseo_primary_category', true),
         'redirect'              => get_post_meta($post['id'], '_yoast_wpseo_redirect', true),
         'score'                 => get_post_meta($post['id'], '_yoast_wpseo_content_score', true),
-        'title'                 => get_post_meta($post['id'], '_yoast_wpseo_title', true),
+		// 'title'                 => get_post_meta($post['id'], '_yoast_wpseo_title', true),
+		'title' => yoastVariableToTitle($post['id']),
         'twitter_description'   => get_post_meta($post['id'], '_yoast_wpseo_twitter-description', true),
         'twitter_image'         => get_post_meta($post['id'], '_yoast_wpseo_twitter-image', true),
         'twitter_image_id'      => get_post_meta($post['id'], '_yoast_wpseo_twitter-image-id', true),
@@ -36,3 +37,25 @@ foreach (WP_API_YOAST_POST_TYPES as $type) {
     },
   ));
 }
+
+function yoastVariableToTitle( $post_id ) {
+    $yoast_title = get_post_meta( $post_id, '_yoast_wpseo_title', true );
+    $title       = strstr( $yoast_title, '%%', true );
+    if ( empty( $title ) ) {
+        $title = get_the_title( $post_id );
+    }
+    $wpseo_titles = get_option( 'wpseo_titles' );
+
+    $sep_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
+    if ( isset( $wpseo_titles['separator'] ) && isset( $sep_options[ $wpseo_titles['separator'] ] ) ) {
+        $sep = $sep_options[ $wpseo_titles['separator'] ];
+    } else {
+        $sep = '-'; //setting default separator if Admin didn't set it from backed
+    }
+
+    $site_title = get_bloginfo( 'name' );
+
+    $meta_title = $title . ' ' . $sep . ' ' . $site_title;
+
+    return $meta_title;
+} 


### PR DESCRIPTION
Your plugin was the third one I've tried in 2 days and it works well. Thank you!

The only problem is:

When using Yoast snippets, the REST api returns unusable strings. For example, if the title in yoast for a given page is set to the snippet %%site_name%% - WP returns `%%site_name%%` without interpolating the actual site name.

This commit adds a function to solve this problem, which I stole from here: https://wordpress.stackexchange.com/questions/315383/how-to-parse-yoast-seo-snippet-variables

I'm speeding along on a project and don't have time to make the code better or to extend the functionality to `metadesc` as I'm not a confident PHP or WP developer. But, if you're interested in including this functionality for your plugin and you leave a critique of this code, I will follow up and improve the code so it can be merged.






